### PR TITLE
allow arm64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -25,8 +25,9 @@ get_arch() {
     case "$(uname -m)" in
         x86_64|amd64) arch="amd64"; ;;
         i686|i386) arch="386"; ;;
+        arm64) arch="arm64"; ;;
         *)
-            echo "Arch '$(uname -m)' not supported!" >&2
+            echo "Arch '$(uname -m)' not supported" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
Tested the get_arch function locally
Note that the `!"` in "...not supported!" causes the double quote to not close properly